### PR TITLE
Don't break password changes

### DIFF
--- a/PlansPlus.safariextension/plansplus.user.js
+++ b/PlansPlus.safariextension/plansplus.user.js
@@ -27,7 +27,7 @@ function plansPlus () {
 	
 	window.localStorage.setItem('inputFocused', 'false');
 	
-	$('textarea, input:text').live('focus', function() {
+	$('textarea, input:text, input:password').live('focus', function() {
 		window.localStorage.setItem('inputFocused', 'true');
 	}).blur(function() {
 		window.localStorage.setItem('inputFocused', 'false');

--- a/plansplus.user.js
+++ b/plansplus.user.js
@@ -50,7 +50,7 @@ function plansPlus () {
 	
 	window.localStorage.setItem('inputFocused', 'false');
 	
-	$('textarea, input:text').live('focus', function() {
+	$('textarea, input:text, input:password').live('focus', function() {
 		window.localStorage.setItem('inputFocused', 'true');
 	}).blur(function() {
 		window.localStorage.setItem('inputFocused', 'false');


### PR DESCRIPTION
Previously, keyboard shortcuts were active in password fields, including the change-your-password form's, which meant that if your password contained a keyboard shortcut, when you entered it, the keyboard shortcut would activate.
Now, they aren't active.